### PR TITLE
Use safe DOM APIs to build the donor table

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -154,17 +154,36 @@ $(document).ready(function () {
     $('#sukromne-osoby').each(function(i, e) {
         var elm = $(e);
         $.getJSON('https://api.darujme.sk/v1/feeds/6bdda09c-356b-4328-9953-103eb78aa44d/donors?per_page=500', function (data) {
-            var table = '<table class="table table-condensed table-supporters"><tbody>';
-            $.each(data.response.donors, function (i, donor) {
-                table += '<tr><td>' + donor.donor_name + '</td><td class="text-right">' + donor.amount + ' &euro;</td></tr>';
-            });
-
-            table += '</tbody>';
-            table += '<tfoot><tr><td>Spolu</td><td class="text-right">' + data.response.metadata.total_amount + ' &euro; </td></tr></tfoot>'
-            table += '</table>';
-            elm.after(table);
+            elm.after(buildDonorTable(data));
         })
     });
+
+    function buildDonorTable(data) {
+        function insertAlignedRow(first, second, target) {
+            var row = target.insertRow();
+            row.insertCell().innerText = first;
+
+            var cell = row.insertCell();
+            cell.classList.add("text-right");
+            cell.innerText = second;
+        }
+
+        var table = document.createElement("table");
+        // IE 11 doesn't support multiple parameters
+        table.classList.add("table");
+        table.classList.add("table-condensed");
+        table.classList.add("table-supporters");
+        var tbody = table.createTBody();
+
+        $.each(data.response.donors, function (i, donor) {
+            insertAlignedRow(donor.donor_name, donor.amount + " \u20AC", tbody);
+        })
+
+        var tfoot = table.createTFoot();
+        insertAlignedRow("Spolu", data.response.metadata.total_amount + " \u20AC", tfoot);
+
+        return table;
+    }
 
     $('#activities #filter .btn').click(function() {
         $('#activities #filter .btn').removeClass('active');


### PR DESCRIPTION
Hi, this fixes an injection vulnerability in the donor table. It uses safe DOM APIs to build the table instead of string concatenations (browser support shouldn't be a problem, no throughout testing on my side was done though). 

There might be easier approaches to fix the issue, but all have some drawbacks:

One is encoding the user-controlled strings (e.g. `donor.donor_name`) like `.replace(/</g, "&lt;").replace(/>/g, "&gt;");` or `$("<div>").text(donor.donor_name).html();`. This, however, might still be subject to mXSS or can be insufficient if the untrusted data is used in a different context in future (e.g. HTML attribute context or JS context). 

Another option is to clean the strings with something like `.replace(/[<>]/g, "");`. This again is insufficient for different contexts, potentially creating issues in future, and it disallows using < and > characters, which someone might want to use in their name 🤷.

Happy to replace the current changes with one of the other options if you prefer those. Just let me know. 